### PR TITLE
Updates the spring framework version to 4.2.2

### DIFF
--- a/gameoflife-web/pom.xml
+++ b/gameoflife-web/pom.xml
@@ -126,19 +126,19 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>3.0.2.RELEASE</version>
+            <version>4.2.2.RELEASE</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>3.0.2.RELEASE</version>
+            <version>4.2.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>3.0.2.RELEASE</version>
+            <version>4.2.2.RELEASE</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Updated gameoflife-web/pom.xml. spring framework version updated from 3.0.2 to 4.2.2.
Resolves the following error while deploying the application to cloud foundry.
Caused by: java.lang.NoClassDefFoundError: org/springframework/context/ApplicationContextInitializer